### PR TITLE
Add GitHub Skills activity to resolve issue #6

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Thursdays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing **GitHub Skills** activity that was announced by the principal in the school assembly.

## Changes
- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Set capacity to 25 participants to accommodate expected high demand
- Scheduled for Thursdays, 3:00 PM - 4:30 PM
- Included description mentioning it's part of the GitHub Certifications program for college applications

## Resolves
Closes #6

## Context
This is a time-sensitive issue as registration was announced to close by the end of this week. Students have been looking for this activity but couldn't find it on the website.